### PR TITLE
Add `divmod` and `pow` to builtins

### DIFF
--- a/ouroboros/__builtins__.py
+++ b/ouroboros/__builtins__.py
@@ -112,6 +112,31 @@ the items of the sequence (or a list of tuples if more than one sequence)."""
             else:
                 result.append(func(*args))
 
+def divmod(a, b):
+    "Return the tuple (x//y, x%y).  Invariant: div*y + mod == x."
+    return (a // b, a % b)
+
+def pow(base, exp, mod=None):
+    """Equivalent to base**exp with 2 arguments or base**exp % mod with 3 arguments
+
+Some types, such as ints, are able to use a more efficient algorithm when
+invoked using the three argument form."""
+    # Reference: https://stackoverflow.com/a/10539256/13884898
+    # arguments, docstring is modified, mod is optional
+    number = 1
+    while exp:
+        if exp & 1:
+            if mod:
+                number = number * base % mod
+            else:
+                number *= base
+        exp >>= 1
+        if mod:
+            base = base * base % mod
+        else:
+            base *= base
+    return number
+
 class _ManagedNewlistHint(object):
     """ Context manager returning a newlist_hint upon entry.
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
I've added `divmod` and `pow` to builtins,
the `divmod` function could be configured further. Since it's just `(a//b, a%b)`
the `pow` one is mostly copied from stack overflow
<!--- What problem does this change solve? -->
Solves a few missing builtins
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented (documented as in docstring? yes)
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
